### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/01-mocking.t
+++ b/t/01-mocking.t
@@ -4,7 +4,7 @@ use BlahBlahBlah;
 
 use Test::More tests => 3;
 
-use_ok('BlahBlahBlah', 'Mocked module BlahBlahBlah loaded');
+use_ok('BlahBlahBlah');
 
 Test::VirtualModule->mock_sub('BlahBlahBlah',
     new => sub {


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.